### PR TITLE
Include default fetch headers for downloads

### DIFF
--- a/src/main/services/ipc-handlers.js
+++ b/src/main/services/ipc-handlers.js
@@ -1604,6 +1604,13 @@ async function handleSpooferAction(
     const maxRetries = maxPlaceIdRetries;
 
     try {
+      // Pre-fill locationsMap so if placeIdArray is empty or an item is missing, we have a clear error
+      for (const item of items) {
+        locationsMap[item.requestId] = {
+          errors: [{ message: placeIdArray.length === 0 ? 'No places found for creator to authorize download' : 'Asset missing from batch response' }]
+        };
+      }
+
       while (placeIdIndex < placeIdArray.length) {
         checkCancelled();
         await checkPaused();
@@ -1814,6 +1821,11 @@ async function handleSpooferAction(
       }
       sendStatusMessage(`Batch request failed: ${error.message}`);
       for (const item of items) {
+        // Only overwrite if we don't already have a valid location or a specific Roblox error for it
+        if (!locationsMap[item.requestId] || locationsMap[item.requestId].errors?.[0]?.message === 'Asset missing from batch response') {
+          locationsMap[item.requestId] = { errors: [{ message: msg }] };
+        }
+        
         const transfer = initialTransferStates.find((t) => t.originalAssetId === item.requestId);
         if (transfer)
           sendTransferUpdate({

--- a/src/main/services/transfer-handlers.js
+++ b/src/main/services/transfer-handlers.js
@@ -426,11 +426,12 @@ async function downloadAnimationAssetWithProgress(
 
   for (let attempt = 1; attempt <= retries + 1; attempt += 1) {
     try {
-      const fetchHeaders = {};
+      const fetchHeaders = {
+        'User-Agent': 'RobloxStudio/WinInet',
+        'Roblox-Browser-Asset-Request': 'false',
+      };
       if (placeId) {
         fetchHeaders['Roblox-Place-Id'] = String(placeId);
-        fetchHeaders['User-Agent'] = 'RobloxStudio/WinInet';
-        fetchHeaders['Roblox-Browser-Asset-Request'] = 'false';
       }
 
       const response = await fetchWithTimeout(


### PR DESCRIPTION
Always set 'User-Agent' and 'Roblox-Browser-Asset-Request' in the default fetchHeaders for downloadAnimationAssetWithProgress. Keep 'Roblox-Place-Id' added only when placeId is provided. This makes header behavior consistent for asset download requests and avoids omitting those headers when placeId is absent.

I hate my life.