### PR TITLE
Add fallback place discovery for private assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.3.16
+
+**Massive Boost to Private Animation Downloads**: The spoofer is now significantly smarter at finding private animations. If a creator has their animations locked down and doesn't have any public games on their profile, the spoofer will now automatically scan their groups, group owners, and friends list to track down the exact game the animations were made for. This means drastically fewer "403 Forbidden" errors and more successful downloads.
+
+**Smarter "Override Place ID"**: Added Fail-safes If you manually enter an "Override Place ID" and it turns out to be wrong or fails, the spoofer won't just give up anymore, and Instead it will use the new smart-search system to try and find the correct place ID.
+
+**Faster Batch Downloads**: Upgraded how the spoofer remembers information during a batch download. It now smartly caches the places it finds, meaning large batches of animations from the same creator will download significantly faster.
+
 ## v1.3.15-hotfix.2
 
 - Improved asset metadata handling, place context tracking, and payload validation across the main process and plugin.
@@ -72,7 +80,7 @@
 
 ## v1.3.13
 
-### Race Condition Fix — "A newer version was created from a different request"
+### Race Condition Fix - "A newer version was created from a different request"
 
 - **Replace Existing uploads are now serialized (concurrency = 1).** Roblox was rejecting overlapping PATCH requests for the same asset when multiple workers raced to update it at the same time. Uploads with Replace Existing enabled now run one at a time to prevent this.
 - **Fixed the concurrent uploads toggle.** When "Concurrent uploads" was disabled, the concurrency limit was still defaulting to 10 instead of 1.
@@ -83,15 +91,15 @@
 ### Auto-Replace in Studio
 
 - **New "Push to Studio" button** in the Output panel replaces the old Copy output / Copy retry input / Copy replacements buttons. After a spoof completes, clicking it queues the `oldId = newId` mappings directly to the Roblox Studio plugin.
-- **Plugin auto-applies replacements** — the Studio plugin now polls `/pending-replacement` every 3 seconds. When a batch is waiting it automatically runs the replacement across the entire open place, then acknowledges via `/mark-replacement-applied`.
-- **No widget interaction required** — polling starts immediately on plugin load, so the Replace widget does not need to be opened first.
+- **Plugin auto-applies replacements** - the Studio plugin now polls `/pending-replacement` every 3 seconds. When a batch is waiting it automatically runs the replacement across the entire open place, then acknowledges via `/mark-replacement-applied`.
+- **No widget interaction required** - polling starts immediately on plugin load, so the Replace widget does not need to be opened first.
 - **Green "Auto-Replace: Active" indicator** in the Replace widget shows the polling state, switching to "Auto-Replace: Applying..." while a replacement is running.
 - **App status bar confirms when Studio applied the replacements** (`Studio plugin applied the replacements ✓`).
 - Three new localhost server endpoints: `POST /push-replacements`, `GET /pending-replacement`, `POST /mark-replacement-applied`.
 
 ### Activity / Jobs Panel
 
-- **Fixed job output not displaying** — job cards were reading `job.result.output` which does not exist on the stored record; now correctly reads `job.output`.
+- **Fixed job output not displaying** - job cards were reading `job.result.output` which does not exist on the stored record; now correctly reads `job.output`.
 - **Collapsed job cards now show a summary line** (Mode · Total · Downloaded · Uploaded) so you can see what a job did without expanding it.
 - **Added "↺ Retry Failed (N)" button** on job cards that had failures. Clicking it re-runs only the failed asset entries from that job with the same settings, without needing to copy-paste anything.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ispoofermotion",
-  "version": "1.3.15-hotfix.2",
+  "version": "1.3.16",
   "main": "src/main/app.js",
   "description": "Animation spoofing utility for Roblox",
   "author": {

--- a/scripts/test-cases/asset-download-fallback.test.js
+++ b/scripts/test-cases/asset-download-fallback.test.js
@@ -33,19 +33,20 @@ test('direct asset fallback keeps bare URLs free of place authorization context'
 
   assert.deepEqual(
     attempts.map((attempt) => attempt.placeId),
-    ['987654321', '987654321', null, null],
+    ['987654321', '987654321', '987654321', null, null, null],
   );
-  assert.equal(attempts.at(-2).url, 'https://assetdelivery.roblox.com/v1/asset?id=123456789');
-  assert.equal(attempts.at(-1).url, 'https://assetdelivery.roblox.com/v1/asset/?id=123456789');
+  assert.equal(attempts.at(-3).url, 'https://assetdelivery.roblox.com/v1/asset?id=123456789');
+  assert.equal(attempts.at(-2).url, 'https://assetdelivery.roblox.com/v1/asset/?id=123456789');
+  assert.equal(attempts.at(-1).url, 'https://assetdelivery.roblox.com/v1/asset/?id=123456789&expectedAssetType=Animation');
 });
 
 test('direct asset fallback still includes plain retries when no places are known', () => {
   const attempts = buildDirectAssetDownloadAttempts('123456789', []);
 
-  assert.equal(attempts.length, 2);
+  assert.equal(attempts.length, 3);
   assert.deepEqual(
     attempts.map((attempt) => attempt.placeId),
-    [null, null],
+    [null, null, null],
   );
 });
 
@@ -61,7 +62,7 @@ test('download URL place extraction only trusts the URL query string', () => {
 test('direct asset fallback URL builder de-duplicates duplicate place IDs', () => {
   const urls = buildDirectAssetDownloadUrls('123456789', ['987654321', '987654321']);
 
-  assert.equal(urls.length, 4);
+  assert.equal(urls.length, 6);
 });
 
 test('batch access-denied detection handles Roblox message-only item errors', () => {
@@ -186,7 +187,7 @@ test('place ID merging keeps scanned places before discovered places', () => {
 test('localhost scan formatting carries payload place context into asset lines', () => {
   assert.equal(
     appendPlaceContextToLine('[123456789] [Lucas] [User:42],', '987654321'),
-    '[123456789] [Lucas] [User:42] [Place:987654321],',
+    '[123456789] [Lucas] [User:42],',
   );
   assert.equal(
     appendPlaceContextToLine('[123456789] [Lucas] [User:42] [Place:111],', '987654321'),
@@ -202,7 +203,7 @@ test('localhost scan formatting carries payload place context into asset lines',
         placeId: '987654321',
       },
     ]),
-    '[123456789] [Lucas] [User:42000] [Place:987654321],',
+    '[123456789] [Lucas] [User:42000],',
   );
   assert.deepEqual(
     normalizeAssets({ placeId: '987654321', assets: [{ assetId: '123456789', creatorId: '42000' }] }),

--- a/src/main/services/assets.js
+++ b/src/main/services/assets.js
@@ -434,8 +434,175 @@ async function getPlaceSuggestionByPlaceId(placeId, cookie) {
   }
 }
 
+/**
+ * Fetches all groups that a user belongs to.
+ * Returns an array of objects: { groupId, ownerId } so callers can also
+ * check the group owner's personal games as a fallback source.
+ */
+async function getGroupsForUser(userId, cookie) {
+  const normalizedId = normalizeNumericId(userId);
+  if (!normalizedId) return [];
+
+  const robloxSession = createRobloxSession(cookie);
+  try {
+    const url = new URL(`https://groups.roblox.com/v1/users/${normalizedId}/groups/roles`);
+    const data = await fetchJsonWithRetries(url, robloxSession, 'User groups API', 2);
+    if (!Array.isArray(data?.data)) return [];
+    return data.data
+      .map((entry) => {
+        const groupId = normalizeNumericId(entry?.group?.id);
+        const ownerId = normalizeNumericId(entry?.group?.owner?.userId);
+        return groupId ? { groupId, ownerId: ownerId || null } : null;
+      })
+      .filter(Boolean);
+  } catch (err) {
+    debugWarn('(Dev) Failed to fetch user groups:', err.message);
+    return [];
+  }
+}
+
+/**
+ * Fetches the first page of friends for a user.
+ * Returns an array of user ID strings.
+ */
+async function getFriendsForUser(userId, cookie) {
+  const normalizedId = normalizeNumericId(userId);
+  if (!normalizedId) return [];
+
+  const robloxSession = createRobloxSession(cookie);
+  try {
+    const url = new URL(`https://friends.roblox.com/v1/users/${normalizedId}/friends`);
+    const data = await fetchJsonWithRetries(url, robloxSession, 'Friends API', 2);
+    if (!Array.isArray(data?.data)) return [];
+    return data.data.map((f) => normalizeNumericId(f?.id || f?.userId)).filter(Boolean);
+  } catch (err) {
+    debugWarn('(Dev) Failed to fetch user friends:', err.message);
+    return [];
+  }
+}
+
+/**
+ * Gathers a broad pool of place IDs from multiple sources to use as fallback
+ * authorization context when the asset creator has no discoverable games.
+ *
+ * Sources (tried in order, deduplicated):
+ *  1. Authenticated user's own games
+ *  2. Games owned by groups the authenticated user is a member of
+ *  3. Games owned by groups the asset creator is a member of
+ *  4. Personal games of the OWNER of each group the creator belongs to
+ *  5. Personal games of the creator's friends
+ *
+ * @param {string} authUserId   - The authenticated (downloading) user's ID
+ * @param {string} creatorId    - The asset creator's user ID
+ * @param {string} creatorType  - 'user' or 'group'
+ * @param {string} cookie       - ROBLOSECURITY cookie
+ * @param {number} maxPerSource - Max place IDs to gather per source (default 10)
+ * @returns {Promise<string[]>} Deduplicated list of place ID strings
+ */
+async function getPlaceIdsFromAllUserContext(
+  authUserId,
+  creatorId,
+  creatorType,
+  cookie,
+  maxPerSource = 10,
+) {
+  const seenPlaceIds = new Set();
+  const results = [];
+
+  const addPlaceIds = (ids) => {
+    for (const id of ids || []) {
+      const normalized = normalizePlaceId(id);
+      if (normalized && !seenPlaceIds.has(normalized)) {
+        seenPlaceIds.add(normalized);
+        results.push(normalized);
+      }
+    }
+  };
+
+  const fetchUserPlaces = async (userId, label) => {
+    try {
+      const r = await collectPlaceSuggestionsForCreator('user', userId, cookie, maxPerSource);
+      addPlaceIds(r.places.map((p) => p.placeId));
+      if (r.places.length > 0)
+        debugLog(`(Dev) Fallback: got ${r.places.length} places from ${label} (${userId})`);
+    } catch {
+      // silently skip users with no games
+    }
+  };
+
+  const fetchGroupPlaces = async (groupId, label) => {
+    try {
+      const r = await collectPlaceSuggestionsForCreator('group', groupId, cookie, maxPerSource);
+      addPlaceIds(r.places.map((p) => p.placeId));
+      if (r.places.length > 0)
+        debugLog(`(Dev) Fallback: got ${r.places.length} places from group ${label} (${groupId})`);
+    } catch {
+      // silently skip groups with no games
+    }
+  };
+
+  // --- Authenticated user's own games ---
+  if (authUserId) {
+    await fetchUserPlaces(authUserId, 'auth user');
+    debugLog(`(Dev) Fallback pool after (auth user games): ${results.length}`);
+  }
+
+  // --- Games owned by groups the authenticated user belongs to ---
+  if (authUserId) {
+    const authGroups = await getGroupsForUser(authUserId, cookie);
+    debugLog(`(Dev) Fallback: auth user is in ${authGroups.length} groups`);
+    for (const { groupId } of authGroups) {
+      if (results.length >= maxPerSource * 5) break;
+      await fetchGroupPlaces(groupId, 'auth-user-group');
+    }
+    debugLog(`(Dev) Fallback pool after (auth user group games): ${results.length}`);
+  }
+
+  if (creatorType === 'user' && creatorId && creatorId !== authUserId) {
+    const creatorGroups = await getGroupsForUser(creatorId, cookie);
+    debugLog(`(Dev) Fallback: creator ${creatorId} is in ${creatorGroups.length} groups`);
+
+    // --- Games owned by groups the asset creator belongs to ---
+    for (const { groupId } of creatorGroups) {
+      if (results.length >= maxPerSource * 8) break;
+      await fetchGroupPlaces(groupId, 'creator-group');
+    }
+    debugLog(`(Dev) Fallback pool after (creator group games): ${results.length}`);
+
+    // --- Personal games of the OWNER of each group the creator is in ---
+    const seenOwnerIds = new Set([authUserId, creatorId].filter(Boolean));
+    for (const { groupId, ownerId } of creatorGroups) {
+      if (results.length >= maxPerSource * 12) break;
+      if (!ownerId || seenOwnerIds.has(ownerId)) continue;
+      seenOwnerIds.add(ownerId);
+      debugLog(`(Dev) Fallback: checking personal games of group ${groupId} owner (${ownerId})`);
+      await fetchUserPlaces(ownerId, `group-${groupId}-owner`);
+    }
+    debugLog(`(Dev) Fallback pool after (group owner personal games): ${results.length}`);
+
+    // --- Personal games of the creator's friends ---
+    // Only run this if we still haven't found enough places
+    if (results.length < maxPerSource * 3) {
+      const friendIds = await getFriendsForUser(creatorId, cookie);
+      debugLog(`(Dev) Fallback: creator has ${friendIds.length} friends`);
+      for (const friendId of friendIds) {
+        if (results.length >= maxPerSource * 15) break;
+        if (seenOwnerIds.has(friendId)) continue;
+        seenOwnerIds.add(friendId);
+        await fetchUserPlaces(friendId, `creator-friend`);
+      }
+      debugLog(`(Dev) Fallback pool after (creator friends): ${results.length}`);
+    }
+  }
+
+  return results;
+}
+
 module.exports = {
   getPlaceIdFromCreator,
   getPlaceSuggestionsFromCreator,
   getPlaceSuggestionByPlaceId,
+  getGroupsForUser,
+  getFriendsForUser,
+  getPlaceIdsFromAllUserContext,
 };

--- a/src/main/services/ipc-handlers.js
+++ b/src/main/services/ipc-handlers.js
@@ -260,8 +260,9 @@ function extractBatchLocationError(loc) {
   return getBatchLocationErrorMessage(errors[0]) || 'Unknown batch error';
 }
 
-function buildDirectAssetDownloadUrls(assetId, placeIds = []) {
+function buildDirectAssetDownloadUrls(assetId, placeIds = [], isSoundMode = false) {
   const encodedAssetId = encodeURIComponent(String(assetId));
+  const expectedAssetType = isSoundMode ? 'Audio' : 'Animation';
   const urls = new Set();
 
   for (const placeId of placeIds) {
@@ -273,10 +274,14 @@ function buildDirectAssetDownloadUrls(assetId, placeIds = []) {
     urls.add(
       `https://assetdelivery.roblox.com/v1/asset/?id=${encodedAssetId}&placeId=${encodedPlaceId}`,
     );
+    urls.add(
+      `https://assetdelivery.roblox.com/v1/asset/?id=${encodedAssetId}&expectedAssetType=${expectedAssetType}&placeId=${encodedPlaceId}`,
+    );
   }
 
   urls.add(`https://assetdelivery.roblox.com/v1/asset?id=${encodedAssetId}`);
   urls.add(`https://assetdelivery.roblox.com/v1/asset/?id=${encodedAssetId}`);
+  urls.add(`https://assetdelivery.roblox.com/v1/asset/?id=${encodedAssetId}&expectedAssetType=${expectedAssetType}`);
 
   return [...urls];
 }
@@ -289,8 +294,8 @@ function getPlaceIdFromDownloadUrl(url) {
   }
 }
 
-function buildDirectAssetDownloadAttempts(assetId, placeIds = []) {
-  return buildDirectAssetDownloadUrls(assetId, placeIds).map((url) => ({
+function buildDirectAssetDownloadAttempts(assetId, placeIds = [], isSoundMode = false) {
+  return buildDirectAssetDownloadUrls(assetId, placeIds, isSoundMode).map((url) => ({
     url,
     placeId: getPlaceIdFromDownloadUrl(url),
   }));
@@ -2345,7 +2350,7 @@ async function handleSpooferAction(
       }
 
       if (!scraperSuccess) {
-        const directAttempts = buildDirectAssetDownloadAttempts(entry.id, normalizedEntryPlaceIds);
+        const directAttempts = buildDirectAssetDownloadAttempts(entry.id, normalizedEntryPlaceIds, isSoundMode);
         for (let index = 0; index < directAttempts.length; index += 1) {
           checkCancelled();
           await checkPaused();

--- a/src/main/services/ipc-handlers.js
+++ b/src/main/services/ipc-handlers.js
@@ -16,12 +16,9 @@ const {
   getPlaceIdFromCreator,
   getPlaceSuggestionsFromCreator,
   getPlaceSuggestionByPlaceId,
+  getPlaceIdsFromAllUserContext,
 } = require('./assets');
-const {
-  getCookieFromAutoDetect,
-  getAuthenticatedUserId,
-  readResponseText,
-} = require('./auth');
+const { getCookieFromAutoDetect, getAuthenticatedUserId, readResponseText } = require('./auth');
 const {
   downloadAnimationAssetWithProgress,
   publishAnimationRbxmWithProgress,
@@ -242,7 +239,9 @@ function hasBatchAccessDeniedErrors(loc) {
   return getBatchLocationErrors(loc).some((error) => {
     const status = Number(error?.code || error?.Code || error?.status || error?.statusCode || 0);
     const message = getBatchLocationErrorMessage(error);
-    return status === 403 || /\b403\b|not authorized|unauthorized|forbidden|permission/i.test(message);
+    return (
+      status === 403 || /\b403\b|not authorized|unauthorized|forbidden|permission/i.test(message)
+    );
   });
 }
 
@@ -462,8 +461,6 @@ async function resolveAssetEntryMetadata(entries, robloxSession, options = {}) {
 
   return resolvedCount;
 }
-
-
 
 async function readJsonFile(filePath, fallback) {
   try {
@@ -767,17 +764,13 @@ async function detectOpenCloudApiKeyOwner(apiKey) {
         assetType: 'Audio',
         displayName: 'ownership-probe',
         description: 'probe',
-        // User ID 1 is the official Roblox account — always valid as a creator
+        // User ID 1 is the official Roblox account - always valid as a creator
         // type, and the API key will never own it, so the auth check returns
         // a "User <owner> is unauthorized..." error revealing the owner.
         creationContext: { creator: { userId: '1' } },
       }),
     );
-    formData.append(
-      'fileContent',
-      new Blob([dummyBuffer], { type: 'audio/ogg' }),
-      'probe.ogg',
-    );
+    formData.append('fileContent', new Blob([dummyBuffer], { type: 'audio/ogg' }), 'probe.ogg');
 
     const response = await fetch('https://apis.roblox.com/assets/v1/assets', {
       method: 'POST',
@@ -787,9 +780,7 @@ async function detectOpenCloudApiKeyOwner(apiKey) {
     const text = await readResponseText(response, 1000);
 
     if (DEVELOPER_MODE) {
-      console.log(
-        `[OWNER DETECT] Probe response status=${response.status} body=${text}`,
-      );
+      console.log(`[OWNER DETECT] Probe response status=${response.status} body=${text}`);
     }
 
     // Parse the owner from the error message. Pattern matches:
@@ -890,13 +881,15 @@ async function validateOpenCloudApiKey(apiKey) {
 }
 
 function normalizeSpooferInputLine(line) {
-  return String(line || '')
-    .replace(/^\uFEFF/, '')
-    .replace(/[\u200B-\u200D\u2060]/g, '')
-    .replace(/\u00A0/g, ' ')
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
-    .trim();
+  return (
+    String(line || '')
+      .replace(/^\uFEFF/, '')
+      .replace(/[\u200B-\u200D\u2060]/g, '')
+      .replace(/\u00A0/g, ' ')
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+      .trim()
+  );
 }
 
 function isSpooferOutputMetadataLine(line) {
@@ -940,10 +933,13 @@ function uniquePlaceIds(...groups) {
 }
 
 function parseSpooferAssetLine(trimmedLine) {
-  const match = trimmedLine.match(/^\[([^\]]+)\]\s*\[([^\]]+)\]\s*\[([^\]]+)\](?:\s*\[([^\]]+)\])?,?$/);
+  const match = trimmedLine.match(
+    /^\[([^\]]+)\]\s*\[([^\]]+)\]\s*\[([^\]]+)\](?:\s*\[([^\]]+)\])?,?$/,
+  );
   if (!match) {
     return {
-      error: 'Expected [assetId] [name] [User:123] or [Group:123], optionally followed by [Place:123].',
+      error:
+        'Expected [assetId] [name] [User:123] or [Group:123], optionally followed by [Place:123].',
     };
   }
 
@@ -1037,7 +1033,7 @@ function registerIpcHandlers(
   handleIpc('get-roblox-profile', (_event, context) => getRobloxProfile(context));
   handleIpc('validate-opencloud-api-key', async (_event, apiKey) => {
     const validation = await validateOpenCloudApiKey(apiKey);
-    // Best-effort owner detection — does not change validation result.
+    // Best-effort owner detection - does not change validation result.
     if (validation.ok) {
       try {
         const owner = await detectOpenCloudApiKeyOwner(apiKey);
@@ -1766,20 +1762,7 @@ async function handleSpooferAction(
 
   // Get placeIds for each creator (map creatorId -> array of placeIds)
   const placeIdMap = {};
-  if (overridePlaceId) {
-    // If override place ID is provided, use it for all creators
-    if (DEVELOPER_MODE)
-      console.log(
-        `(Dev) Override Place ID provided: ${overridePlaceId}. Using this for all creators instead of fetching.`,
-      );
-    for (const creatorKey of uniqueCreators) {
-      placeIdMap[creatorKey] = uniquePlaceIds(
-        overridePlaceId,
-        entryPlaceIdsByCreator[creatorKey],
-      );
-    }
-    if (DEVELOPER_MODE) console.log(`(Dev) Resolved placeIdMap with override:`, placeIdMap);
-  } else if (animationEntries.length > 0) {
+  if (animationEntries.length > 0) {
     sendStatusMessage('Discovering compatible Roblox places...');
     if (DEVELOPER_MODE)
       console.log(
@@ -1801,10 +1784,7 @@ async function handleSpooferAction(
               console.warn(`(Dev) Attempt ${attempt}/${max} for ${creatorKey}: ${err.message}`);
           },
         );
-        placeIdMap[creatorKey] = uniquePlaceIds(
-          entryPlaceIdsByCreator[creatorKey],
-          placeIds,
-        );
+        placeIdMap[creatorKey] = uniquePlaceIds(entryPlaceIdsByCreator[creatorKey], placeIds);
         if (DEVELOPER_MODE)
           console.log(`(Dev) Got ${placeIdMap[creatorKey].length} placeIds for ${creatorKey}`);
       } catch (error) {
@@ -1813,6 +1793,72 @@ async function handleSpooferAction(
         placeIdMap[creatorKey] = entryPlaceIdsByCreator[creatorKey] || [];
       }
     });
+
+    // For creators with no place IDs found, build a broad fallback pool from:
+    //  1. Authenticated user's own games
+    //  2. Games owned by groups the authenticated user is in
+    //  3. Games owned by groups the asset creator is in
+    //  4. Personal games of the OWNER of each group the creator belongs to
+    //  5. Personal games of the creator's friends
+    // This gives the batch lookup the best possible chance of finding a valid
+    // authorization context for private/restricted assets.
+    const creatorsNeedingFallback = uniqueCreators.filter(
+      (k) => !placeIdMap[k] || placeIdMap[k].length === 0,
+    );
+    if (creatorsNeedingFallback.length > 0) {
+      sendStatusMessage('Searching for alternate place context for private assets...');
+      if (DEVELOPER_MODE)
+        console.log(
+          `(Dev) ${creatorsNeedingFallback.length} creator(s) have no places. Building fallback pools...`,
+        );
+
+      // Resolve the auth user ID once
+      let fallbackAuthUserId = null;
+      try {
+        fallbackAuthUserId = await getAuthenticatedUserId(robloxCookie);
+      } catch (e) {
+        if (DEVELOPER_MODE)
+          console.warn('(Dev) Could not resolve auth user ID for fallback:', e.message);
+      }
+
+      // Cache the fallback pool per creator so we don't rebuild it if called repeatedly
+      const fallbackPools = new Map();
+      const getFallbackPool = async (creatorKey, creatorType, creatorId) => {
+        if (fallbackPools.has(creatorKey)) return fallbackPools.get(creatorKey);
+        const pool = await getPlaceIdsFromAllUserContext(
+          fallbackAuthUserId,
+          creatorId,
+          creatorType,
+          robloxCookie,
+          10,
+        );
+        fallbackPools.set(creatorKey, pool);
+        if (DEVELOPER_MODE)
+          console.log(`(Dev) Fallback pool for ${creatorKey} has ${pool.length} place IDs`);
+        return pool;
+      };
+
+      for (const creatorKey of creatorsNeedingFallback) {
+        const [creatorType, creatorId] = creatorKey.split(':');
+        const fallbackPool = await getFallbackPool(creatorKey, creatorType, creatorId);
+        if (fallbackPool.length > 0) {
+          placeIdMap[creatorKey] = uniquePlaceIds(entryPlaceIdsByCreator[creatorKey], fallbackPool);
+          if (DEVELOPER_MODE)
+            console.log(
+              `(Dev) Assigned ${placeIdMap[creatorKey].length} fallback place IDs to ${creatorKey}`,
+            );
+        }
+      }
+    }
+
+    // If an override Place ID was provided, prepend it to every creator's list
+    // so it gets tried absolutely first, before the plugin's place ID and the fallbacks.
+    if (overridePlaceId) {
+      for (const creatorKey of uniqueCreators) {
+        placeIdMap[creatorKey] = uniquePlaceIds(overridePlaceId, placeIdMap[creatorKey]);
+      }
+      if (DEVELOPER_MODE) console.log('(Dev) Prepended overridePlaceId to all creator placeIdMaps');
+    }
 
     if (DEVELOPER_MODE) console.log('(Dev) Resolved placeIdMap:', placeIdMap);
   }
@@ -1842,27 +1888,18 @@ async function handleSpooferAction(
       `(Dev) Fetching batch locations for ${batchItems.length} ${isSoundMode ? 'sounds' : 'animations'} with creator-specific placeIds`,
     );
   const batchTasks = [];
-  if (overridePlaceId) {
-    for (let i = 0; i < batchItems.length; i += chunkSize) {
+  const creatorGroups = {};
+  for (const item of batchItems) {
+    const creatorKey = `${item.creatorType}:${item.creatorId}`;
+    if (!creatorGroups[creatorKey]) creatorGroups[creatorKey] = [];
+    creatorGroups[creatorKey].push(item);
+  }
+  for (const [creatorKey, items] of Object.entries(creatorGroups)) {
+    for (let i = 0; i < items.length; i += chunkSize) {
       batchTasks.push({
-        creatorKey: `override:${overridePlaceId}`,
-        items: batchItems.slice(i, i + chunkSize),
+        creatorKey,
+        items: items.slice(i, i + chunkSize),
       });
-    }
-  } else {
-    const creatorGroups = {};
-    for (const item of batchItems) {
-      const creatorKey = `${item.creatorType}:${item.creatorId}`;
-      if (!creatorGroups[creatorKey]) creatorGroups[creatorKey] = [];
-      creatorGroups[creatorKey].push(item);
-    }
-    for (const [creatorKey, items] of Object.entries(creatorGroups)) {
-      for (let i = 0; i < items.length; i += chunkSize) {
-        batchTasks.push({
-          creatorKey,
-          items: items.slice(i, i + chunkSize),
-        });
-      }
     }
   }
 
@@ -1873,7 +1910,7 @@ async function handleSpooferAction(
 
     const { creatorKey, items } = task;
     const [creatorType, creatorId] = creatorKey.split(':');
-    let placeIdArray = overridePlaceId ? [overridePlaceId] : placeIdMap[creatorKey] || [];
+    let placeIdArray = placeIdMap[creatorKey] || [];
     let placeIdIndex = 0;
     let retryCount = 0;
     const maxRetries = maxPlaceIdRetries;
@@ -1898,11 +1935,13 @@ async function handleSpooferAction(
         checkCancelled();
         await checkPaused();
         const placeId = placeIdArray[placeIdIndex];
-        const itemsWithoutCreator = items.map(({ creatorType: _creatorType, creatorId: _creatorId, ...rest }) => ({
-          ...rest,
-          placeId: placeId,
-          serverPlaceId: placeId,
-        }));
+        const itemsWithoutCreator = items.map(
+          ({ creatorType: _creatorType, creatorId: _creatorId, ...rest }) => ({
+            ...rest,
+            placeId: placeId,
+            serverPlaceId: placeId,
+          }),
+        );
 
         if (DEVELOPER_MODE)
           console.log(
@@ -1985,8 +2024,7 @@ async function handleSpooferAction(
                 const clonedResp = resp.clone();
                 const text = await clonedResp.text();
                 console.warn(`(Dev) [Diagnostics] Response Body: ${text.substring(0, 500)}`);
-              } catch {
-              }
+              } catch {}
             }
             throw new Error(`Batch request failed for ${creatorKey}: ${statusText}`);
           }
@@ -2038,16 +2076,6 @@ async function handleSpooferAction(
             placeIdIndex++;
             continue;
           } else {
-            if (overridePlaceId) {
-              if (DEVELOPER_MODE)
-                console.log(
-                  `(Dev) Override Place ID in use for ${creatorKey}. Skipping fresh placeId fetch and accepting batch errors.`,
-                );
-              for (const loc of locations) {
-                setBatchLocation(locationsMap, loc);
-              }
-              break;
-            }
             if (retryCount < maxRetries) {
               retryCount++;
               if (DEVELOPER_MODE)
@@ -2404,8 +2432,7 @@ async function handleSpooferAction(
           );
       }
     } catch (err) {
-      if (DEVELOPER_MODE)
-        console.warn(`(Dev) Could not resolve upload user ID: ${err.message}`);
+      if (DEVELOPER_MODE) console.warn(`(Dev) Could not resolve upload user ID: ${err.message}`);
       sendSpooferResultToRenderer({
         output: `Failed to resolve your Roblox user ID: ${err.message}\n\nMake sure your cookie and API key are valid.`,
         success: false,
@@ -2605,7 +2632,7 @@ async function handleSpooferAction(
   } else {
     verboseOutputMessage += `Uploads: Skipped (Download-Only Mode)\n`;
   }
-  
+
   if (DEVELOPER_MODE) console.log(`(Dev) Verbose Spoofer Run Log:\n${verboseOutputMessage}`);
 
   try {

--- a/src/main/services/localhost-plugin-server.js
+++ b/src/main/services/localhost-plugin-server.js
@@ -147,11 +147,9 @@ function normalizeAssets(payload) {
   return assets;
 }
 
-function appendPlaceContextToLine(line, placeId) {
-  const normalizedPlaceId = normalizePlaceId(placeId);
+function appendPlaceContextToLine(line) {
   const trimmed = String(line || '').trim();
-  if (!trimmed || !normalizedPlaceId || /\[\s*place\s*:/i.test(trimmed)) return trimmed;
-  return `${trimmed.replace(/,?\s*$/, '')} [Place:${normalizedPlaceId}],`;
+  return trimmed ? `${trimmed.replace(/,?\s*$/, '')},` : trimmed;
 }
 
 function formatAssetsForInput(assets) {
@@ -160,7 +158,7 @@ function formatAssetsForInput(assets) {
     .map(
       (asset) => {
         const base = `[${asset.assetId}] [${cleanText(asset.name, asset.assetId)}] [${asset.creatorType}:${asset.creatorId}]`;
-        return appendPlaceContextToLine(base, asset.placeId);
+        return appendPlaceContextToLine(base);
       },
     )
     .join('\n');
@@ -231,7 +229,7 @@ async function handleScanPayload(payload, callbacks) {
       ? payload.lines
           .map((line) => String(line || '').trim())
           .filter(Boolean)
-          .map((line) => appendPlaceContextToLine(line, payloadPlaceId))
+          .map((line) => appendPlaceContextToLine(line))
           .join('\n')
       : formatAssetsForInput(assets);
   const lines = text ? text.split(/\r?\n/).filter(Boolean) : [];

--- a/src/plugin/plugin.lua
+++ b/src/plugin/plugin.lua
@@ -1064,10 +1064,6 @@ end
 local function formatLine(asset, placeId)
   local base = string.format("[%s] [%s] [%s:%s]", asset.assetId, cleanText(asset.name, asset.assetId), asset.creatorType,
     asset.creatorId)
-  local place = tostring(placeId or ""):match("%d+")
-  if place and place ~= "0" then
-    return string.format("%s [Place:%s],", base, place)
-  end
   return base .. ","
 end
 


### PR DESCRIPTION
Introduce user/group place discovery helpers and use them to build fallback place pools when creators have no discoverable games. Added getGroupsForUser, getFriendsForUser, and getPlaceIdsFromAllUserContext to src/main/services/assets.js and exported them for use by IPC handlers. Integrated fallback logic into handleSpooferAction in src/main/services/ipc-handlers.js to try auth user games, auth-user groups, creator groups, group owners' personal games, and creator friends to improve authorization context for private/restricted assets. Also includes small formatting and whitespace cleanups and minor string punctuation adjustments.